### PR TITLE
Org site refactor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,7 +13,7 @@ assignees: ''
 Please submit your feedback to the most relevant repository:
 - [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
-- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+- [opendi-org/api-specification](https://github.com/opendi-org/api-specification) for feedback related to the OpenDI API Specification
 
 **Always use the Issue search feature to see if your report, request, or feedback already exists!**  
 If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 (To save space, you may delete this section of the template before submitting your issue)
 
 Please submit your feedback to the most relevant repository:
-- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
 - [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
 

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -13,7 +13,7 @@ assignees: ''
 Please submit your feedback to the most relevant repository:
 - [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
-- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+- [opendi-org/api-specification](https://github.com/opendi-org/api-specification) for feedback related to the OpenDI API Specification
 
 **Always use the Issue search feature to see if your report, request, or feedback already exists!**  
 If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -11,7 +11,7 @@ assignees: ''
 (To save space, you may delete this section of the template before submitting your issue)
 
 Please submit your feedback to the most relevant repository:
-- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
 - [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Welcome! You're currently browsing source files for the OpenDI public website - 
 
 ## Get started
 
-If you're looking to explore the standards or learn more about the project, [start on the website.](https://opendi-org.github.io/landing-site/)  
+If you're looking to explore the standards or learn more about the project, [start on the website.](https://opendi.org)  
 If you'd like to go to the roles and user stories website directly, use [this direct link](https://opendi-org.github.io/roles-user-stories) 
 
-If you'd like to contribute to OpenDI, check the [contribution guide.](https://opendi-org.github.io/landing-site/How%20To%20Contribute/)
+If you'd like to contribute to OpenDI, check the [contribution guide.](https://opendi.org/How%20To%20Contribute/)
 
 Want to engage in community discussion? Join the [OpenDI Discord server!](https://discord.gg/FtAX3JStJz)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,10 +13,10 @@ const config = {
   favicon: 'img/opendi-icon-small.png',
 
   // Set the production url of your site here
-  url: 'http://roles-user-stories.opendi.org',
+  url: 'http://opendi.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/roles-user-stories/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -109,7 +109,7 @@ const config = {
               },
               {
                 label: 'Roles and User Stories',
-                href: 'http://roles-user-stories.opendi.org'
+                href: 'http://opendi.org/roles-user-stories'
               },
               {
                 label: 'API Specification',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -112,8 +112,8 @@ const config = {
                 href: 'http://roles-user-stories.opendi.org'
               },
               {
-                label: 'JSON Schema',
-                href: 'http://json-schema.opendi.org'
+                label: 'API Specification',
+                href: 'http://opendi.org/api-specification'
               },
             ],
           },

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-roles-user-stories.opendi.org


### PR DESCRIPTION
# Summary

Made changes to prepare to rename the landing-site repo to opendi-org.github.io, so that it forms the base of the organization's GitHub Pages site.
This will allow us to remove the custom subdomains from the roles and user stories site and what is currently the JSON Schema site.
Those subdomain-sites will instead be hosted at `opendi.org/<repo-name>/`

This Roles and User Stories repo is currently **not** planned to be renamed.

**Note:** When merged to `dev`, these changes will break several links in the `Next` version of the docs. This is expected for now. These links will work again once changes have been merged to `main` **and** all repos have been renamed and had the appropriate settings tweaked. See planned renaming and settings changes below.

# Details

Updated GitHub links/references to landing-site, now refer to opendi-org.github.io. Some minor accompanying wording changes.

Updated any GitHub repo links to point to a repo called api-specification instead of json-schema.
Updated any opendi site links to point to opendi.org/api-specification instead of json-schema.opendi.org
Minor associated wording changes.

Updated links opendi.org/roles-user-stories instead of roles-user-stories.opendi.org
Deleted associated CNAME file. No longer needed.

# Planned renaming and settings changes

Once all changes are merged to `main`:
- This repo will NOT be renamed. It will become a [project site](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites) with the same name it currently has.
- The `Custom domain` setting in the repo's [Pages settings](https://github.com/opendi-org/roles-user-stories/settings/pages) menu will be reset to the default (empty) value, instead of `roles-user-stories.opendi.org`. This will cause the Roles and User Stories site to be hosted in the [default location](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages#using-a-custom-domain-across-multiple-repositories) based on the organization site's custom domain (`https://opendi.org`). The final URL for the Roles and User Stories site will be `https://opendi.org/roles-user-stories`.