### PR TITLE
Fix links from Gamma site migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Welcome! You're currently browsing source files for the OpenDI Roles and User St
 If you're looking to explore the standards or learn more about the project, [start on the website.](https://opendi.org)  
 If you'd like to go to the roles and user stories website directly, use [this direct link](https://opendi-org.github.io/roles-user-stories) 
 
-If you'd like to contribute to OpenDI, check the [contribution guide.](https://opendi.org/How%20To%20Contribute/)
+If you'd like to contribute to OpenDI, check the [contribution guide.](https://opendi.org/contribute)
 
 Want to engage in community discussion? Join the [OpenDI Discord server!](https://discord.gg/FtAX3JStJz)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -200,15 +200,15 @@ const config = {
               },
               {
                 label: 'Roles and User Stories',
-                href: 'http://opendi.org/roles-user-stories'
+                href: 'https://opendi-org.github.io/roles-user-stories/'
               },
               {
                 label: 'API Specification',
-                href: 'http://opendi.org/api-specification'
+                href: 'https://opendi-org.github.io/api-specification/'
               },
               {
                 label: 'CDM Authoring Tool',
-                href: 'http://opendi.org/cdd-authoring-tool'
+                href: 'https://opendi-org.github.io/cdd-authoring-tool/'
               }
             ],
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -77,17 +77,17 @@ const sidebars = {
         {
           type: 'link',
           label: 'Roles and User Stories',
-          href: 'http://opendi.org/roles-user-stories'
+          href: 'https://opendi-org.github.io/roles-user-stories/'
         },
         {
           type: 'link',
           label: 'API Specification',
-          href: 'http://opendi.org/api-specification'
+          href: 'https://opendi-org.github.io/api-specification/'
         },
         {
             type: 'link',
             label: 'CDM Authoring Tool',
-            href: 'http://opendi.org/cdd-authoring-tool'
+            href: 'https://opendi-org.github.io/cdd-authoring-tool/'
         }
       ]
     }

--- a/versioned_sidebars/version-Live-sidebars.json
+++ b/versioned_sidebars/version-Live-sidebars.json
@@ -73,17 +73,17 @@
         {
           "type": "link",
           "label": "Roles and User Stories",
-          "href": "http://opendi.org/roles-user-stories"
+          "href": "https://opendi-org.github.io/roles-user-stories/"
         },
         {
           "type": "link",
           "label": "API Specification",
-          "href": "http://opendi.org/api-specification"
+          "href": "https://opendi-org.github.io/api-specification/"
         },
         {
           "type": "link",
           "label": "CDM Authoring Tool",
-          "href": "http://opendi.org/cdd-authoring-tool"
+          "href": "https://opendi-org.github.io/cdd-authoring-tool/"
         }
       ]
     }


### PR DESCRIPTION
Gamma migration broke the old opendi.org links for Roles/User Stories, API Spec, and CDD Authoring Tool. These have been reverted to their github.io links.  
We also have a new link for a newer contribution guide page.

- https://opendi.org/roles-user-stories -> https://opendi-org.github.io/roles-user-stories/
- https://opendi.org/api-specification -> https://opendi-org.github.io/api-specification/
- https://opendi.org/cdd-authoring-tool -> https://opendi-org.github.io/cdd-authoring-tool/
- https://opendi.org/How%20To%20Contribute/ -> https://opendi.org/contribute

Fixed links in README, site footer, and site sidebars.